### PR TITLE
Add schema.org contact metadata

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -26,18 +26,20 @@ title: minuscode - Contact
   <div class="wrapper">
     <div class="grid grid--full">
       <div class="grid__item three-fifths portable-one-whole">
-        <div class="contacts">
+        <div class="contacts" itemscope itemtype="http://schema.org/Organization">
             <a href="http://goo.gl/maps/PbVoI" target="_blank"><img src="/images/misc/map_garrett.jpg" alt="Rua Garrett, nº80, 3ºB"></a>
           <div class="contacts-container">
-            <h2><i class="icon-briefcase"></i>Minuscode</h2>
-            <div class="address">
-              <p><a href="http://goo.gl/maps/yVApP" target="_blank">Rua Garrett, nº80, 3ºB</a></p>
-              <p>1200-204 Lisboa</p>
+            <h2 itemprop="name"><i class="icon-briefcase"></i>Minuscode</h2>
+            <div class="address" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+              <p><a href="http://goo.gl/maps/yVApP" target="_blank">
+                <span itemprop="streetAddress">Rua Garrett, nº80, 3ºB</span>
+              </a></p>
+              <p><span itemprop="postalCode">1200-204</span>&nbsp;<span itemprop="addressLocality">Lisboa</span></p>
             </div>
 
-            <p><i class="icon-mail"></i><span>E-mail:</span> <a href="mailto:contact@minuscode.com">contact@minuscode.com</a></p>
-            <p><i class="icon-mobile"></i><span>Phone:</span> +351 914 317 367</p>
-            <!--<p><i class="icon-mobile"></i><span>Phone:</span> +351 215 924 018</p>-->
+            <p itemprop="email"><i class="icon-mail"></i><span>E-mail:</span> <a href="mailto:contact@minuscode.com">contact@minuscode.com</a></p>
+            <p itemprop="telephone"><i class="icon-mobile"></i><span>Phone:</span> +351 914 317 367</p>
+            <!--<p itemprop="telephone"><i class="icon-mobile"></i><span>Phone:</span> +351 215 924 018</p>-->
           </div>
           <img class="shade" src="/images/misc/bottom-shade.png" alt="">
         </div>


### PR DESCRIPTION
Fixes issue #2 

Minuscode contacts is semantically marked to improve recognition by search engines following the schema.org vocabularies.