### PR TITLE
Fix mobile site nav (Fix #23)

### DIFF
--- a/css/src/ui/_page.scss
+++ b/css/src/ui/_page.scss
@@ -14,7 +14,6 @@ html {
   margin-right: auto;
   margin-left: auto;
   padding: 0 50px;
-  overflow: hidden;
 
   @include media-query(lap) {
     padding: 0 25px;


### PR DESCRIPTION
regression introduced in 0e3f458

The "overflow: hidden" rule was hidding the nav menu.
It was used because of a horizontal overflow on the "About Us" page but that overflow is caused by another grid layout error and will be handled on issue #24 