### PR TITLE
Fix "about us" page in smaller viewports

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -23,26 +23,20 @@ category: about_us
 
 <div class="content about-us">
 
-  <div class="wrapper shuffle">
+  <div class="wrapper grid shuffle">
 
     {% for post in site.categories['about-us'] %}
 
-      <div class="member">
-        <div class="grid">
-
-          <div class="grid__item one-whole lap-one-half push--lap-one-half palm-one-whole">
-            <div class="member-pic">
-              <img src="/images/team/{{ post.picture }}" alt="{{ post.alt_name }}">
-            </div>
-            <hr><!--
-            --><div class="grid__item one-whole portable-one-whole">
-              <h2>{{ post.alt_name }}</h2>
-              <p>
-                  <span>{{ post.role }}</span>
-              </p> 
-            </div>
-          </div>
-
+      <div class="member grid__item one-whole lap-one-half desk-one-half">
+        <div class="member-pic">
+          <img src="/images/team/{{ post.picture }}" alt="{{ post.alt_name }}">
+        </div>
+        <hr><!--
+        --><div>
+          <h2>{{ post.alt_name }}</h2>
+          <p>
+              <span>{{ post.role }}</span>
+          </p>
         </div>
         {% unless forloop.last %}
           

--- a/css/src/ui/_page.scss
+++ b/css/src/ui/_page.scss
@@ -14,7 +14,6 @@ html {
   margin-right: auto;
   margin-left: auto;
   padding: 0 50px;
-  overflow: hidden;
 
   @include media-query(lap) {
     padding: 0 25px;

--- a/css/src/ui/_page.scss
+++ b/css/src/ui/_page.scss
@@ -363,9 +363,27 @@ html {
 
 .member {
   display: inline-block;
-  margin:0 2%;
-  width: 45%;
   text-align: center;
+
+  @include media-query(palm) {
+    padding-left: 0;
+  }
+
+  @include media-query(lap) {
+    padding: 0;
+
+    &:nth-of-type(2n) { padding-left: 1%; }
+    &:nth-of-type(2n+1) { padding-right: 1%; }
+  }
+
+  @include media-query(desk) {
+    padding: 0;
+
+    &:nth-of-type(2n) { padding-left: 1%; }
+    &:nth-of-type(2n+1) { padding-right: 1%; }
+  }
+
+
   h2 {
     color: $red;
     font-family: $brand-serif;


### PR DESCRIPTION
Changes:
- "palm" breakpoint now shows 1 member per line
- revamped grid code (caused layout overflow and had redundant code)

Fix #24 