### PR TITLE
remove duplicated h1 and img ALT text (fix #34)

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -7,11 +7,9 @@ category: about_us
 <div class="masthead masthead-about-us">
 
   <div class="wrapper">
-
-    <h1 class="hidden">We're a small multidisciplinary team based in Europe.</h1>
-
-    <img src="/images/misc/about-us.png" alt="We're a small multidisciplinary team based in Europe">
-
+    <h1>
+      <img src="/images/misc/about-us.png" alt="We're a small multidisciplinary team based in Europe.">
+    </h1>
     <p>
       <span>We provide development, design and management services and we also have been working</span> <span>closely in the startup environment. Our goal is to deliver the most flexible and simple project</span> <span>to fit your needs so that you can manage and work it out after we’ve concluded our work.</span>
       <span>We can also arrange you a marketing strategy based on your objectives and target audience.</span>
@@ -32,7 +30,7 @@ category: about_us
 
           <div class="grid__item one-whole lap-one-half push--lap-one-half palm-one-whole">
             <div class="member-pic">
-              <img src="/images/team/{{ post.picture }}" alt="{{ post.alt_name }}">
+              <img src="/images/team/{{ post.picture }}" alt="">
             </div>
             <hr><!--
             --><div class="grid__item one-whole portable-one-whole">

--- a/consulting/index.html
+++ b/consulting/index.html
@@ -6,15 +6,12 @@ title: Consulting - minuscode
 <div class="masthead masthead-consulting">
 
   <div class="wrapper">
-
-    <h1 class="hidden">we design - we develop - WE DELIVER</h1>
-
-    <img src="/images/misc/consulting.png" alt="we design - we develop - WE DELIVER">
-
+    <h1>
+      <img src="/images/misc/consulting.png" alt="we design - we develop - WE DELIVER">
+    </h1>
     <p>
       <span>Because just developing isn't enough for us, we like to build and we like to</span> <span>watch it grow but most of all we are focused on you getting the results you need,</span> <span>because a website isn't just a website but a conduit to enhance your brand and the</span><span>means to carve out a stage for your audience.</span>
     </p>
-
   </div>
 
 </div><!-- /masthead -->

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,17 +6,14 @@ title: Contact - minuscode
 <div class="masthead masthead-contact">
 
   <div class="wrapper">
-
-    <h1 class="hidden">Just get in touch</h1>
-
-    <img src="/images/misc/contact.png" alt="Just get in touch">
-
+    <h1>
+      <img src="/images/misc/contact.png" alt="Just get in touch">
+    </h1>
     <p>
       <span>We provide development, design and management services and we also have been working</span> <span>closely in the startup environment. Our goal is to deliver the most flexible and simple project</span> <span>to fit your needs so that you can manage and work it out after we’ve concluded our work.</span>
       <span>We can also arrange you a marketing strategy based on your objectives and target audience.</span>
       <span class="block-element"><strong>Twitter: </strong><a href="https://twitter.com/minuscode">@minuscode</a></span>
     </p>
-
   </div>
 
 </div><!-- /masthead -->


### PR DESCRIPTION
h1 is now populated by the img since both screen-readers and search engines fallback to use the image alt attribute.

However, measures should be taken in the future to avoid using images with textual content on the website.